### PR TITLE
usefetch cleanup and heading style changes

### DIFF
--- a/src/components/Heading/Heading.css
+++ b/src/components/Heading/Heading.css
@@ -43,10 +43,10 @@
   font-weight: bold;
 }
 
-.text-italics {
+.text-italic {
   font-style: italic;
 }
 
 .text-underline {
-  font-style: underline;
+  text-decoration: underline;
 }

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -25,7 +25,7 @@ const useFetch = <T extends {}>({
 
   const abortControllerRef = useRef<AbortController | null>(null);
 
-  useEffect(() => {}, []);
+  // useEffect(() => {}, []);
 
   useEffect(() => {
     const fetchData = async () => {


### PR DESCRIPTION
Made changes to Heading.css file

the class name should be .text-italic earlier it was .text-italics
.text-italic{
  font-style: italic;
}

changed the rule name to text-decoration.
.text-underline{
  text-decoration: underline;
}

removed a blank useEffect from useFetch hook.